### PR TITLE
Encode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 
 sudo: false
 cache:
@@ -9,16 +9,15 @@ cache:
 
 before_deploy:
   - rm -f target/original-*.jar
-  - export PLUGIN_FILE=$(ls target/*.jar)
   - echo "Deploying release to GitHub releases..."
 deploy:
   provider: releases
   api_key:
     secure: XNdHJ0YhiqWsR6+MoldKgxpseQQMFkbSGAbYWicARiaUnDqoaRCCPHboxDdfzx2EDKBOs3LiVA4eRafrg7ymzPV5xx7nEaB6kla2MxM8oJoIOMdMiiXgt2XSCpMsMllFykJpECc6IPr1Hqmt3Inh1e0BFcYRqM+u/05CgydcvnnLoxlP47EPmct0pBORrwRXKGqMegNwpygWfxJB2iSIGFUHW8UR40vWswVEOS1fcGfn5aAD2qPjnF9VQr170y0Eo3AVFGvpS1Dj5z0t5LxCEF0CPLs12vqhSSu4Y+G3/UwR+wwLBv9DX0A6JLA0xBCxbCwcrbhnH+hB5F1W35HkxGrepo6ZBYQdUPZw/qCuklQ7KAJMKULuK8pFV6AxThDZE8lNLduSbKsKIPutNUAHWvLYxLC+5G6lWAOvp6l81ORBjGFOPk6oErAsyIYVWrsF5f1nW6wnhnLpyHQjvwCeW9JhUtPt9eUkKaaiPbVDqqIieeCNJfIStmesxyvZTr/jmZTrZW+g2u5FARY6SFSjX39mafPCXGYbfrpqp39tdM4lnWkdEiSDRBtKh3TrXwDEgqlBM5UWUmFY1QSOAE/NHHhDXIUtM/v4FILYLDsA0UzvEdzKWtIRiiqrdUaw6LiPGQ4LVeYtqNM3igEKm6McJJ/QPBatA7/iCy+iFM/1JTs=
   file:
-    - "${PLUGIN_FILE}"
+    - "target/*.jar"
   skip_cleanup: true
   on:
     tags: true
-    jdk: oraclejdk8
+    jdk: openjdk8
     repo: irgendwr/TelegramAlert

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ TelegramAlert allows you to send [Graylog](https://www.graylog.org) alert messag
 
 ## Requirements
 
-Requires Graylog 2.0 or later. It's recommended to use the [latest Graylog release](https://www.graylog.org/products/latestversion).
+Requires Graylog 2.4 or later. It's recommended to use the [latest Graylog release](https://www.graylog.org/products/latestversion).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,39 @@
-# Telegram Alert
+# TelegramAlert
 
-[![GitHub Release](https://img.shields.io/github/release/irgendwr/TelegramAlert.svg)](https://github.com/irgendwr/TelegramAlert/releases)
 [![Build Status](https://travis-ci.org/irgendwr/TelegramAlert.svg?branch=master)](https://travis-ci.org/irgendwr/TelegramAlert)
+[![GitHub Release](https://img.shields.io/github/release/irgendwr/TelegramAlert.svg)](https://github.com/irgendwr/TelegramAlert/releases)
 [![Graylog Marketplace](https://img.shields.io/badge/Graylog-Marketplace-blue.svg)](https://marketplace.graylog.org/addons/8a67cfdf-8c1c-4d17-87bf-db38e79015f1)
 
 TelegramAlert allows you to send [Graylog](https://www.graylog.org) alert messages to a specified [Telegram](https://telegram.org) chat.
 
 ## Requirements
 
-Requires Graylog 2.0 or later.
+Requires Graylog 2.0 or later. It's recommended to use the [latest Graylog release](https://www.graylog.org/products/latestversion).
 
 ## Installation
 
-[Download the plugin](https://github.com/irgendwr/TelegramAlert/releases/latest)
-and place the `.jar` file in your plugins folder that is configured in your `graylog.conf`
+1. Download the [latest TelegramAlert release](https://github.com/irgendwr/TelegramAlert/releases/latest)
+and place the `telegram-alert-x.x.x.jar` file in your plugins folder that is configured in your `graylog.conf`
 as described in the [Graylog documentation](http://docs.graylog.org/en/latest/pages/plugins.html#installing-and-loading-plugins).
 
-Restart graylog-server: `service graylog-server restart`
+2. Restart your graylog-server, i.e. `service graylog-server restart`.
+
+3. Configure an alert notification as described in the next section.
 
 ## Usage
 
-### Step 1
+### Step 1 - Create bot
 
-Create a new bot with the [BotFather](https://t.me/BotFather).
+Create a new Telegram bot with the [BotFather](https://t.me/BotFather).
 
-### Step 2
+### Step 2 - Get channel ID
 
 Send the Bot a message and go to `https://api.telegram.org/bot<BOT_TOKEN>/getUpdates`
 (replace `<BOT_TOKEN>` with the token you got from BotFather) to get your ID, as shown below.
 
 ![Chat ID](https://raw.githubusercontent.com/irgendwr/TelegramAlert/master/screenshots/chat_id.png)
 
-### Step 3
+### Step 3 - Add alert notification
 
 Add a new alert notification in your Graylog-interface and select `Telegram Alert` as the notification type.
 
@@ -39,6 +41,12 @@ The message is a template that can be configured as described in the [Graylog Do
 
 ![Add alert notification](https://raw.githubusercontent.com/irgendwr/TelegramAlert/master/screenshots/add_alert_notification.png)
 ![Create new Telegram Alert](https://raw.githubusercontent.com/irgendwr/TelegramAlert/master/screenshots/new_telegram_alert.png)
+
+## Update
+
+To update the plugin you need to remove the old `telegram-alert-x.x.x.jar` file from your plugins folder and follow the [installation](#Installation) instructions again.
+
+You may need to remove and re-create your Telegram Alert Notifications.
 
 ## Build
 
@@ -65,4 +73,8 @@ TravisCI builds and uploads the release artifacts automatically.
 
 ## Credits
 
-Thanks to [Alexey Medov](https://vk.com/snikerspro) for his valuable ideas and generous donation!
+Thanks to:
+
+- Alexey Medov (@kakogoxepa) - *for his valuable ideas and generous donation!*
+- Everyone that [gave this repo a star](https://github.com/irgendwr/TelegramAlert/stargazers) :star: - *you keep me motivated* :slightly_smiling_face: 
+- [Contributors](https://github.com/irgendwr/TelegramAlert/graphs/contributors) that submitted useful [pull-requests](https://github.com/irgendwr/TelegramAlert/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+is%3Amerged) or opened good issues with suggestions or a detailed bug report.

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,12 @@
     <name>TelegramAlert</name>
     <description>Allows you to send alert messages to a specified Telegram chat.</description>
     <url>https://irgendwr.github.io/TelegramAlert/</url>
+
+    <developers>
+        <developer>
+            <name>Jonas Bögle</name>
+        </developer>
+    </developers>
     
     <scm>
         <connection>scm:git:https://github.com/irgendwr/TelegramAlert.git</connection>
@@ -22,9 +28,17 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <graylog2.version>2.0.0</graylog2.version>
-        <httpclient.version>4.5.5</httpclient.version>
-        <json.version>20180813</json.version>
+
+        <!-- Skip unnecessary build steps -->
+        <maven.source.skip>true</maven.source.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.site.skip>true</maven.site.skip>
+
+        <graylog2.version>3.1.0</graylog2.version>
+        <httpclient.version>4.5.9</httpclient.version>
+        <json.version>20190722</json.version>
     </properties>
 
     <dependencies>
@@ -34,6 +48,13 @@
             <version>${graylog2.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!--<dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <version>${auto-value.version}</version>
+            <scope>provided</scope>
+        </dependency>-->
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
@@ -47,11 +68,38 @@
     </dependencies>
     
     <build>
+        <resources>
+            <resource><directory>build</directory></resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <skipAssembly>true</skipAssembly>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Graylog-Plugin-Properties-Path>${project.groupId}.${project.artifactId}</Graylog-Plugin-Properties-Path>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.1</version>
                 <configuration>
                     <minimizeJar>false</minimizeJar>
                 </configuration>

--- a/src/main/java/de/sandstorm_projects/telegramAlert/TelegramAlarmCallback.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/TelegramAlarmCallback.java
@@ -92,12 +92,6 @@ public class TelegramAlarmCallback implements AlarmCallback {
         model.put("backlog_size", backlog.size());
         model.put("stream_url", buildStreamLink(result, stream));
 
-        List<String> test = new ArrayList<>();
-        test.add("one");
-        test.add("two");
-        test.add("three");
-        model.put("test", test);
-
         return model;
     }
 

--- a/src/main/java/de/sandstorm_projects/telegramAlert/TelegramAlarmCallback.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/TelegramAlarmCallback.java
@@ -12,6 +12,7 @@ import com.google.inject.Inject;
 
 import de.sandstorm_projects.telegramAlert.bot.ParseMode;
 import de.sandstorm_projects.telegramAlert.bot.TelegramBot;
+import de.sandstorm_projects.telegramAlert.template.RawBracketsRenderer;
 import de.sandstorm_projects.telegramAlert.template.RawNoopRenderer;
 import de.sandstorm_projects.telegramAlert.template.TelegramHTMLEncoder;
 import de.sandstorm_projects.telegramAlert.template.TelegramMarkdownEncoder;
@@ -35,9 +36,8 @@ public class TelegramAlarmCallback implements AlarmCallback {
     @Inject
     public TelegramAlarmCallback(Engine engine) {
         templateEngine = engine;
-        NamedRenderer rawRenderer = new RawNoopRenderer();
-        templateEngine.registerNamedRenderer(rawRenderer);
-
+        templateEngine.registerNamedRenderer(new RawNoopRenderer());
+        templateEngine.registerNamedRenderer(new RawBracketsRenderer());
     }
 
     @Override
@@ -92,6 +92,12 @@ public class TelegramAlarmCallback implements AlarmCallback {
         model.put("backlog_size", backlog.size());
         model.put("stream_url", buildStreamLink(result, stream));
 
+        List<String> test = new ArrayList<>();
+        test.add("one");
+        test.add("two");
+        test.add("three");
+        model.put("test", test);
+
         return model;
     }
 
@@ -121,7 +127,7 @@ public class TelegramAlarmCallback implements AlarmCallback {
         String alertStart = Tools.getISO8601String(dateAlertStart);
         String alertEnd = Tools.getISO8601String(dateAlertEnd);
 
-        return getGraylogURL() + "streams/" + stream.getId() + "/messages?rangetype=absolute&from=" + alertStart + "&to=" + alertEnd + "&q=*";
+        return getGraylogURL() + "streams/" + stream.getId() + "/messages?rangetype=absolute&from=" + alertStart + "&to=" + alertEnd;
     }
 
     /*private String buildMessageLink(String index, String id) {

--- a/src/main/java/de/sandstorm_projects/telegramAlert/TelegramModule.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/TelegramModule.java
@@ -3,7 +3,6 @@ package de.sandstorm_projects.telegramAlert;
 import org.graylog2.plugin.PluginModule;
 
 public class TelegramModule extends PluginModule {
-    @SuppressWarnings("unused")
     protected void configure() {
         addAlarmCallback(TelegramAlarmCallback.class);
     }

--- a/src/main/java/de/sandstorm_projects/telegramAlert/TelegramPluginMetadata.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/TelegramPluginMetadata.java
@@ -9,6 +9,8 @@ import java.util.Collections;
 import java.util.Set;
 
 public class TelegramPluginMetadata implements PluginMetaData {
+    private static final String PLUGIN_PROPERTIES = "de.sandstorm_projects.telegramAlert/graylog-plugin.properties";
+
     @Override
     public String getUniqueId() {
         return TelegramPlugin.class.getPackage().getName();
@@ -21,7 +23,7 @@ public class TelegramPluginMetadata implements PluginMetaData {
 
     @Override
     public String getAuthor() {
-        return "Jonas Bögle";
+        return "Jonas Bögle @irgendwr";
     }
 
     @Override
@@ -31,7 +33,7 @@ public class TelegramPluginMetadata implements PluginMetaData {
 
     @Override
     public Version getVersion() {
-        return new Version(2, 1, 1);
+        return Version.fromPluginProperties(getClass(), PLUGIN_PROPERTIES, "version", Version.from(0, 0, 0, "unknown"));
     }
 
     @Override
@@ -41,7 +43,8 @@ public class TelegramPluginMetadata implements PluginMetaData {
 
     @Override
     public Version getRequiredVersion() {
-        return new Version(2, 0, 0);
+        return Version.from(2, 4, 0);
+        //return Version.fromPluginProperties(getClass(), PLUGIN_PROPERTIES, "graylog.version", Version.from(2, 4, 0, "unknown"));
     }
 
     @Override

--- a/src/main/java/de/sandstorm_projects/telegramAlert/bot/ParseMode.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/bot/ParseMode.java
@@ -1,0 +1,103 @@
+package de.sandstorm_projects.telegramAlert.bot;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class ParseMode {
+    // values
+    public static final String TEXT = "Text";
+    public static final String MARKDOWN = "Markdown";
+    public static final String HTML = "HTML";
+
+    // number of values
+    private static final int SIZE = 3;
+
+    // list of values
+    public static final List<String> VALUES = new ArrayList<>(SIZE);
+    static {
+        VALUES.add(TEXT);
+        VALUES.add(MARKDOWN);
+        VALUES.add(HTML);
+    }
+    // options for config
+    public static final Map<String, String> OPTIONS = new HashMap<>(SIZE);
+    static {
+        OPTIONS.put("text", TEXT);
+        OPTIONS.put("Markdown", MARKDOWN);
+        OPTIONS.put("HTML", HTML);
+    }
+
+    // value
+    private final String mode;
+
+    /**
+     * Selects a parse mode.
+     * @param str value
+     * @require ParseMode.VALUES.contains(str)
+     */
+    private ParseMode(String str) {
+        assert VALUES.contains(str);
+        this.mode = str;
+    }
+
+    /**
+     * @return Text parse mode.
+     */
+    public static ParseMode text() {
+        return new ParseMode(TEXT);
+    }
+
+    /**
+     * See https://core.telegram.org/bots/api#markdown-style
+     * @return Markdown parse mode.
+     */
+    public static ParseMode markdown() {
+        return new ParseMode(MARKDOWN);
+    }
+
+    /**
+     * See https://core.telegram.org/bots/api#html-style
+     * @return HTML parse mode.
+     */
+    public static ParseMode html() {
+        return new ParseMode(HTML);
+    }
+
+    public static ParseMode fromString(String str) {
+        for (String mode : VALUES) {
+            if (mode.toLowerCase().equals(str.toLowerCase())) {
+                return new ParseMode(mode);
+            }
+        }
+        return text();
+    }
+
+    public String value() {
+        return mode;
+    }
+
+    @Override
+    public String toString() {
+        return value();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof ParseMode) {
+            return equals((ParseMode) obj);
+        } else {
+            return false;
+        }
+    }
+
+    public boolean equals(ParseMode pm) {
+        return pm.mode.equals(mode);
+    }
+
+    @Override
+    public int hashCode() {
+        return VALUES.indexOf(mode);
+    }
+}

--- a/src/main/java/de/sandstorm_projects/telegramAlert/config/TelegramAlarmCallbackConfig.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/config/TelegramAlarmCallbackConfig.java
@@ -17,12 +17,10 @@ public class TelegramAlarmCallbackConfig {
 
         configurationRequest.addField(new TextField(
                 Config.MESSAGE, "Message",
-                "[${stream.title}](${stream_url}): ${alert_condition.title}\n" +
-                "```\n" +
-                "${foreach backlog message}\n" +
-                "${message.message;raw}\n\\n" +
-                "${end}\n" +
-                "```",
+                "<a href=\"${stream_url}\">${stream.title}</a>: ${alert_condition.title}\n" +
+                "<code>${foreach backlog message}\n" +
+                "${message.message}\n" +
+                "${end}</code>",
                 "See http://docs.graylog.org/en/latest/pages/streams/alerts.html#email-alert-notification for more details.",
                 ConfigurationField.Optional.NOT_OPTIONAL,
                 Attribute.TEXTAREA
@@ -34,7 +32,7 @@ public class TelegramAlarmCallbackConfig {
         ));
 
         configurationRequest.addField(new DropdownField(
-                Config.PARSE_MODE, "Parse Mode", ParseMode.MARKDOWN, ParseMode.OPTIONS,
+                Config.PARSE_MODE, "Parse Mode", ParseMode.HTML, ParseMode.OPTIONS,
                 "See https://core.telegram.org/bots/api#formatting-options for more information on formatting.",
                 ConfigurationField.Optional.NOT_OPTIONAL
         ));

--- a/src/main/java/de/sandstorm_projects/telegramAlert/config/TelegramAlarmCallbackConfig.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/config/TelegramAlarmCallbackConfig.java
@@ -1,5 +1,6 @@
 package de.sandstorm_projects.telegramAlert.config;
 
+import de.sandstorm_projects.telegramAlert.bot.ParseMode;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationException;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
@@ -7,9 +8,6 @@ import org.graylog2.plugin.configuration.fields.ConfigurationField;
 import org.graylog2.plugin.configuration.fields.TextField;
 import org.graylog2.plugin.configuration.fields.TextField.Attribute;
 import org.graylog2.plugin.configuration.fields.DropdownField;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class TelegramAlarmCallbackConfig {
     private static final String ERROR_NOT_SET = "%s is mandatory and must not be empty.";
@@ -22,7 +20,7 @@ public class TelegramAlarmCallbackConfig {
                 "[${stream.title}](${stream_url}): ${alert_condition.title}\n" +
                 "```\n" +
                 "${foreach backlog message}\n" +
-                "${message.message}\n\\n" +
+                "${message.message;raw}\n\\n" +
                 "${end}\n" +
                 "```",
                 "See http://docs.graylog.org/en/latest/pages/streams/alerts.html#email-alert-notification for more details.",
@@ -35,12 +33,8 @@ public class TelegramAlarmCallbackConfig {
                 ConfigurationField.Optional.NOT_OPTIONAL
         ));
 
-        Map<String, String> parseMode = new HashMap<>(3);
-        parseMode.put("text", "Text");
-        parseMode.put("Markdown", "Markdown");
-        parseMode.put("HTML", "HTML");
         configurationRequest.addField(new DropdownField(
-                Config.PARSE_MODE, "Parse Mode", "Markdown", parseMode,
+                Config.PARSE_MODE, "Parse Mode", ParseMode.MARKDOWN, ParseMode.OPTIONS,
                 "See https://core.telegram.org/bots/api#formatting-options for more information on formatting.",
                 ConfigurationField.Optional.NOT_OPTIONAL
         ));
@@ -56,7 +50,7 @@ public class TelegramAlarmCallbackConfig {
                 ConfigurationField.Optional.NOT_OPTIONAL
         ));
         configurationRequest.addField(new TextField(
-                Config.PROXY, "Proxy", null,
+                Config.PROXY, "Proxy", "",
                 "Proxy address in the following format: <ProxyAddress>:<Port>",
                 ConfigurationField.Optional.OPTIONAL
         ));

--- a/src/main/java/de/sandstorm_projects/telegramAlert/template/RawBracketsRenderer.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/template/RawBracketsRenderer.java
@@ -7,11 +7,29 @@ import com.floreysoft.jmte.renderer.RawRenderer;
 import java.util.Locale;
 import java.util.Map;
 
-public class RawNoopRenderer implements NamedRenderer, RawRenderer {
+public class RawBracketsRenderer implements NamedRenderer, RawRenderer {
 
     @Override
     public String render(Object obj, String format, Locale locale, Map<String, Object> model) {
-        return obj.toString();
+        String string = obj.toString();
+        StringBuilder sb = new StringBuilder(string.length());
+        for (int i = 0; i < string.length(); i++) {
+            char c = string.charAt(i);
+
+            switch (c) {
+                case '[':
+                    // replace with "FULLWIDTH LEFT SQUARE BRACKET" (U+FF3B, Ps): ［
+                    sb.append("［");
+                    break;
+                case ']':
+                    // replace with "FULLWIDTH RIGHT SQUARE BRACKET" (U+FF3D, Pe)
+                    sb.append("］");
+                    break;
+                default:
+                    sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 
     @SuppressWarnings("unused") // graylog 2.0
@@ -21,7 +39,7 @@ public class RawNoopRenderer implements NamedRenderer, RawRenderer {
 
     @Override
     public String getName() {
-        return "raw";
+        return "brackets";
     }
 
     @Override

--- a/src/main/java/de/sandstorm_projects/telegramAlert/template/RawNoopRenderer.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/template/RawNoopRenderer.java
@@ -1,0 +1,30 @@
+package de.sandstorm_projects.telegramAlert.template;
+
+import com.floreysoft.jmte.NamedRenderer;
+import com.floreysoft.jmte.RenderFormatInfo;
+import com.floreysoft.jmte.renderer.RawRenderer;
+
+import java.util.Locale;
+
+public final class RawNoopRenderer implements NamedRenderer, RawRenderer {
+
+    @Override
+    public String render(Object obj, String format, Locale locale) {
+        return obj.toString();
+    }
+
+    @Override
+    public String getName() {
+        return "raw";
+    }
+
+    @Override
+    public RenderFormatInfo getFormatInfo() {
+        return null;
+    }
+
+    @Override
+    public Class<?>[] getSupportedClasses() {
+        return new Class<?>[]{ String.class };
+    }
+}

--- a/src/main/java/de/sandstorm_projects/telegramAlert/template/TelegramHTMLEncoder.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/template/TelegramHTMLEncoder.java
@@ -1,0 +1,36 @@
+package de.sandstorm_projects.telegramAlert.template;
+
+
+import com.floreysoft.jmte.encoder.Encoder;
+
+/**
+ * Encodes the HTML special characters that Telegram supports, as described in
+ * <a href="https://core.telegram.org/bots/api#html-style">https://core.telegram.org/bots/api#html-style</a>.
+ */
+public class TelegramHTMLEncoder implements Encoder {
+
+    @Override
+    public String encode(String string) {
+        StringBuilder sb = new StringBuilder((int) (string.length() * 1.2));
+        for (int i = 0; i < string.length(); i++) {
+            char c = string.charAt(i);
+            switch (c) {
+                case '&':
+                    sb.append("&amp;");
+                    break;
+                case '"':
+                    sb.append("&quot;");
+                    break;
+                case '<':
+                    sb.append("&lt;");
+                    break;
+                case '>':
+                    sb.append("&gt;");
+                    break;
+                default:
+                    sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/de/sandstorm_projects/telegramAlert/template/TelegramMarkdownEncoder.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/template/TelegramMarkdownEncoder.java
@@ -15,7 +15,6 @@ public class TelegramMarkdownEncoder implements Encoder {
         for (int i = 0; i < string.length(); i++) {
             char c = string.charAt(i);
 
-            //TODO: test if this is reliable
             switch (c) {
                 case '_':
                     sb.append("\\_");

--- a/src/main/java/de/sandstorm_projects/telegramAlert/template/TelegramMarkdownEncoder.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/template/TelegramMarkdownEncoder.java
@@ -1,0 +1,38 @@
+package de.sandstorm_projects.telegramAlert.template;
+
+
+import com.floreysoft.jmte.encoder.Encoder;
+
+/**
+ * Encodes the Markdown special characters that Telegram supports, as described in
+ * <a href="https://core.telegram.org/bots/api#markdown-style">https://core.telegram.org/bots/api#markdown-style</a>.
+ */
+public class TelegramMarkdownEncoder implements Encoder {
+
+    @Override
+    public String encode(String string) {
+        StringBuilder sb = new StringBuilder((int) (string.length() * 1.2));
+        for (int i = 0; i < string.length(); i++) {
+            char c = string.charAt(i);
+
+            //TODO: test if this is reliable
+            switch (c) {
+                case '_':
+                    sb.append("\\_");
+                    break;
+                case '*':
+                    sb.append("\\*");
+                    break;
+                case '[':
+                    sb.append("\\[");
+                    break;
+                case '`':
+                    sb.append("\\`");
+                    break;
+                default:
+                    sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/resources/de.sandstorm_projects.telegramAlert/graylog-plugin.properties
+++ b/src/main/resources/de.sandstorm_projects.telegramAlert/graylog-plugin.properties
@@ -1,0 +1,12 @@
+# The plugin version
+version=${project.version}
+
+# The required Graylog server version
+#graylog.version=${graylog.version}
+
+# When set to true (the default) the plugin gets a separate class loader
+# when loading the plugin. When set to false, the plugin shares a class loader
+# with other plugins that have isolated=false.
+#
+# Do not disable this unless this plugin depends on another plugin!
+#isolated=true


### PR DESCRIPTION
Changes:

- variables in template are now encoded depending on the selected parse mode (closes #16)
- added "raw" and "brackets" renderers for special cases where you do not want variables to be escaped
- the default template and parse mode was changed, you will need to update existing notification settings!
- plugin now **requires at least graylog v2.4+** but targets graylog 3.1.0
- other minor changes:
  - travis now builds using `openjdk8` instead of `oraclejdk8`
  - minor code refactor
  - upgraded dependencies
  - updated readme