### PR TITLE
Authentication options for http proxy

### DIFF
--- a/src/main/java/de/sandstorm_projects/telegramAlert/TelegramAlarmCallback.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/TelegramAlarmCallback.java
@@ -63,6 +63,8 @@ public class TelegramAlarmCallback implements AlarmCallback {
         
         bot = new TelegramBot(config.getToken());
         bot.setProxy(config.getProxy());
+        bot.setProxyUser(config.getProxyUser());
+        bot.setProxyPassword(config.getProxyPassword());
         bot.setParseMode(parseMode);
     }
 

--- a/src/main/java/de/sandstorm_projects/telegramAlert/config/Config.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/config/Config.java
@@ -7,4 +7,6 @@ public class Config {
     public static final String TOKEN = "telegram_token";
     public static final String GRAYLOG_URL = "graylog_url";
     public static final String PROXY = "proxy";
+    public static final String PROXY_USER = "proxy_user" ;
+    public static final String PROXY_PASSWORD = "proxy_password";
 }

--- a/src/main/java/de/sandstorm_projects/telegramAlert/config/TelegramAlarmCallbackConfig.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/config/TelegramAlarmCallbackConfig.java
@@ -50,8 +50,19 @@ public class TelegramAlarmCallbackConfig {
         ));
         configurationRequest.addField(new TextField(
                 Config.PROXY, "Proxy", "",
-                "Proxy address in the following format: <ProxyAddress>:<Port>",
+                "Http proxy address in the following format: <ProxyAddress>:<Port>",
                 ConfigurationField.Optional.OPTIONAL
+        ));
+        configurationRequest.addField(new TextField(
+                Config.PROXY_USER, "Proxy user", "",
+                "Proxy user",
+                ConfigurationField.Optional.OPTIONAL
+        ));
+        configurationRequest.addField(new TextField(
+                Config.PROXY_PASSWORD, "Proxy password", "",
+                "Proxy password",
+                ConfigurationField.Optional.OPTIONAL,
+                Attribute.IS_PASSWORD
         ));
 
         return configurationRequest;

--- a/src/main/java/de/sandstorm_projects/telegramAlert/config/TelegramAlarmCallbackConfigValues.java
+++ b/src/main/java/de/sandstorm_projects/telegramAlert/config/TelegramAlarmCallbackConfigValues.java
@@ -55,4 +55,8 @@ public class TelegramAlarmCallbackConfigValues {
     public String getProxy() {
         return config.getString(Config.PROXY);
     }
+
+    public String getProxyUser() { return config.getString(Config.PROXY_USER); }
+
+    public String getProxyPassword() { return config.getString(Config.PROXY_PASSWORD); }
 }


### PR DESCRIPTION
Added authentication options for http proxy to allow to use squid or something like that as company's proxy. It was necessary with RKN blocks in Russia. Maybe in the future there will be _socks5_ proxy support, but it's difficult to do on Java. Tested on Graylog 3.1.3.